### PR TITLE
fix: build on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+cfg-if = "1.0.0"
 criterion = "0.5.1"
 monoio = "0.2.4"
 


### PR DESCRIPTION
Fix the macOS build: the definition of struct FusionRuntime differs between macOS and Linux, so we need to handle them separately.